### PR TITLE
Fix URL in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpentelemetrySentry.MixProject do
   use Mix.Project
 
-  @source_url "https://github.com/scripbox/opentelemetry_exq"
+  @source_url "https://github.com/scripbox/opentelemetry_sentry"
   @version "0.1.0"
 
   def project do


### PR DESCRIPTION
The previous value was an invalid URL, meaning that the GitHub link on Hex was broken.